### PR TITLE
Jitteriness, Coordinate Saving and Other Changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "d3-graph",
   "version": "0.1.0",
   "private": true,
+  "[javascript]": {
+        "editor.defaultFormatter": "vscode.typescript-language-features"
+    },
   "dependencies": {
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
@@ -41,5 +44,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+    
   }
 }

--- a/src/NetworkGraph.js
+++ b/src/NetworkGraph.js
@@ -148,12 +148,12 @@ const NetworkGraph = () => {
             handleAddNode();
         } else if (event.key === '+' && selectedNode && !selectedLink) {
             handleAddLink();
-        }
-        if (event.key === 'Shift') {
+        } else if (event.code === 'KeyA' && event.shiftKey) {
+            setSelectedNodes([...nodes]);
+            updateNodeBorders([...nodes]);
+        } else if (event.key === 'Shift') {
             setShiftPressed(true)
-
         }
-
     };
 
     const handleKeyUp = (event) => {
@@ -505,7 +505,7 @@ const NetworkGraph = () => {
         simulation.alpha(loAlpha).restart(); // Use a lower alpha value to minimize layout disruptions
         prevNodesNumRef.current = currNodesNumRef.current;
         prevShownNodesNumRef.current = currShownNodesNumRef.current;
-        if (shiftRef.current == false) {
+        if (shiftRef.current == false && selectedNodes.length < 2) {
 
             updateNodeBorders(selectedNode ? [selectedNode] : [0]); // Update node borders initially
         }
@@ -634,26 +634,28 @@ const NetworkGraph = () => {
         }
         if (selectedNodes) {
             for (var i of selectedNodes) {
-                i.shape = newShape;
-                switch (newShape) {
-                    case 'Atomic ER':
-                        i.color = '#ADD8E6';
-                        break;
-                    case 'aER':
-                        i.color = 'orange';
-                        i.stroke = "black";
+                if (i != 0) {
+                    i.shape = newShape;
+                    switch (newShape) {
+                        case 'Atomic ER':
+                            i.color = '#ADD8E6';
+                            break;
+                        case 'aER':
+                            i.color = 'orange';
+                            i.stroke = "black";
 
-                        break;
-                    case 'iER':
-                        i.color = 'red';
-                        i.stroke = "black";
-                        break;
-                    case 'rER':
-                        i.color = 'green';
-                        i.stroke = "black";
-                        break;
-                    default:
-                        i.color = color('default');
+                            break;
+                        case 'iER':
+                            i.color = 'red';
+                            i.stroke = "black";
+                            break;
+                        case 'rER':
+                            i.color = 'green';
+                            i.stroke = "black";
+                            break;
+                        default:
+                            i.color = color('default');
+                    }
                 }
             }
             setNodes([...nodes]); // Trigger re-render to update node shape and color
@@ -670,8 +672,9 @@ const NetworkGraph = () => {
         }
         else if (selectedNodes && selectedNodes.length > 0) {
             for (var i of selectedNodes) {
-                console.log(i)
-                i.size = newSize
+                if (i != 0) {
+                    i.size = newSize
+                }
             }
             setNodes([...nodes]);
 

--- a/src/NetworkGraph.js
+++ b/src/NetworkGraph.js
@@ -610,6 +610,7 @@ const NetworkGraph = () => {
         }
         if(selectedNodes){
             for(var i of selectedNodes){
+                if(i != 0){
             i.shape = newShape;
             switch (newShape) {
                 case 'Atomic ER':
@@ -632,6 +633,7 @@ const NetworkGraph = () => {
                     i.color = color('default');
             }
         }
+    }
         setNodes([...nodes]); // Trigger re-render to update node shape and color
     }
 
@@ -646,8 +648,9 @@ const NetworkGraph = () => {
         }
         else if (selectedNodes && selectedNodes.length > 0) {
             for(var i of selectedNodes){
-               console.log(i)
+              if( i != 0){
                 i.size = newSize
+              }
             }
             setNodes([...nodes]);
            

--- a/src/NetworkGraph.js
+++ b/src/NetworkGraph.js
@@ -900,18 +900,41 @@ const NetworkGraph = () => {
         }
     };
 
-    const handleFilterNodes = (filterType) => {
-        // Update nodes with hidden property based on filterType
-        const updatedNodes = nodes.map(node => {
+// Function to save nodes to Local Storage
+const saveNodesToLocalStorage = (nodes) => {
+    localStorage.setItem('nodes', JSON.stringify(nodes));
+};
+
+// Function to load nodes from Local Storage
+const loadNodesFromLocalStorage = () => {
+    const savedNodes = localStorage.getItem('nodes');
+    if (savedNodes) {
+        return JSON.parse(savedNodes);
+    }
+    return null; // Return null if no nodes are saved
+};
+
+
+const handleFilterNodes = (filterType) => {
+    // Save the updated nodes to Local Storage
+    var saved = loadNodesFromLocalStorage
+    if( saved == null){
+    saveNodesToLocalStorage(updatedNodes);
+    }
+
+    let updatedNodes;
+
+    switch (filterType) {
+        case "1":
+    updatedNodes = nodes.map(node => {
             let hidden = false;
             if (node.id === 0 || node.id === 54321) {
                 hidden = false; // Always show nodes with id 1 and 2
             } 
-            else {
-                switch (filterType) {
-                    case "1":
-                        hidden = !(node.shape === 'aER' || node.shape === 'rER');
-                        // Find last node(connected to end) to use later
+            else {   
+                hidden = !(node.shape === 'aER' || node.shape === 'rER');
+            }
+                   
 
     // Iterate backwards through the nodes array
 for (let i = nodes.length - 1; i >= 0; i--) {
@@ -940,108 +963,200 @@ for (let i = nodes.length - 1; i >= 0; i--) {
     }
 }
 
-                
-                        break;
-                    case "2":
-                        //clear any modifications made to the dataset from View 1
+        return { ...node, hidden };
+        });
 
-                        for(const i of nodes){
-                            if(i.shape == "aER" || i.id == 54321){
-                                if(i.id != 54321){
-                                i.comesAfter = null
-                                }
-                                else{
-                                    var node_id = i.comesAfter
-                                    var curr = nodes[node_id-3]
-                                    if( curr && curr.shape == "aER"){
-                                        i.comesAfter = null
-                                    }
-                                    for (let k = nodes.length - 1; k >= 0; k--){
-                                        let curr = nodes[k];
-                                        if(curr.shape == "iER"){
-                                            console.log(curr.id);
-                                            i.comesAfter = curr.id;
-                                            break;
-                                        }
-                                    }
-                                  
-                                }
-                            }
-                        }
-                        hidden = node.shape == 'Atomic ER';
-                        break;
-                    case "3":
-                         //clear any modifications made to the dataset from View 1
+        break;
 
-                         for(const i of nodes){
-                            if(i.shape == "aER" || i.id == 54321){
-                                if(i.id != 54321){
-                                i.comesAfter = null
-                                }
-                                else{
-                                    var node_id = i.comesAfter
-                                    var curr = nodes[node_id-3]
-                                    if( curr && curr.shape == "aER"){
-                                        i.comesAfter = null
-                                    }
-                                    for (let k = nodes.length - 1; k >= 0; k--){
-                                        let curr = nodes[k];
-                                        if(curr.shape == "iER"){
-                                            console.log(curr.id);
-                                            i.comesAfter = curr.id;
-                                            break;
-                                        }
-                                    }
-                                  
-                                }
-                            }
-                        }
 
-                        hidden = false; // Show all nodes
-                        break;
-                    case "4":
+        default:
+            // For all other cases, load the nodes from Local Storage
+            const savedNodes = loadNodesFromLocalStorage();
+            if (savedNodes) {
+                updatedNodes = savedNodes.map(node => {
+                    let hidden;
 
-                     //clear any modifications made to the dataset from View 1
+                    switch (filterType) {
+                        case "2":
+                            hidden = node.shape === 'Atomic ER';
 
-                     for(const i of nodes){
-                        if(i.shape == "aER" || i.id == 54321){
-                            if(i.id != 54321){
-                            i.comesAfter = null
-                            }
-                            else{
-                                var node_id = i.comesAfter
-                                var curr = nodes[node_id-3]
-                                if( curr && curr.shape == "aER"){
-                                    i.comesAfter = null
-                                }
-                                for (let k = nodes.length - 1; k >= 0; k--){
-                                    let curr = nodes[k];
-                                    if(curr.shape == "iER"){
-                                        console.log(curr.id);
-                                        i.comesAfter = curr.id;
-                                        break;
-                                    }
-                                }
-                              
-                            }
-                        }
+                            // (Your custom logic to update nodes in case "2")
+
+                            break;
+                        case "3":
+                            // (Your custom logic to update nodes in case "3")
+                            hidden = false;
+                            break;
+                        case "4":
+                            // (Your custom logic to update nodes in case "4")
+                            hidden = false;
+                            break;
+                        default:
+                            hidden = false;
+                            break;
                     }
 
-
-                        break;
-                    default:
-                        hidden = false;
-                }
+                    return { ...node, hidden };
+                });
+            } else {
+                // Fallback if no saved nodes are found
+                console.error("No saved nodes found in Local Storage.");
+                return;
             }
+            break;
+    }
 
-            return {
-                ...node,
-                hidden
-            };
-        });
-        setNodes([...updatedNodes]);
+    // Update the nodes state with the modified nodes
+    setNodes(updatedNodes);
+};
 
-    };
+
+//     const handleFilterNodes = (filterType) => {
+//   // Save the current nodes to Local Storage before making changes
+//   saveNodesToLocalStorage(nodes);
+
+//   let updatedNodes;
+
+//     updatedNodes = nodes.map(node => {
+//             let hidden = false;
+//             if (node.id === 0 || node.id === 54321) {
+//                 hidden = false; // Always show nodes with id 1 and 2
+//             } 
+//             else {
+//                 switch (filterType) {
+//                     case "1":
+//                         hidden = !(node.shape === 'aER' || node.shape === 'rER');
+//                         // Find last node(connected to end) to use later
+
+//     // Iterate backwards through the nodes array
+// for (let i = nodes.length - 1; i >= 0; i--) {
+
+//     const node = nodes[i];
+//       // Find the previous aER node in the array
+//       const prevAER = nodes.slice(0, i).reverse().find(n => n.shape === 'aER');
+
+
+//     if(node.id == 54321){
+//         if(prevAER ){
+//         node.comesAfter = prevAER.id;
+//         }
+//     }
+
+//     // Link all aER nodes together with a comesAfter relation
+//     if (node.shape === 'aER') {
+        
+//         // If there is a previous aER node, set the comesAfter property
+//         if (prevAER) {
+//             node.comesAfter = prevAER.id;
+//         } 
+//         else {
+//             node.comesAfter = 0; // No previous aER, set to a default value
+//         }
+//     }
+// }
+
+                
+//                         break;
+//                     case "2":
+//                         //clear any modifications made to the dataset from View 1
+
+//                         for(const i of nodes){
+//                             if(i.shape == "aER" || i.id == 54321){
+//                                 if(i.id != 54321){
+//                                 i.comesAfter = null
+//                                 }
+//                                 else{
+//                                     var node_id = i.comesAfter
+//                                     var curr = nodes[node_id-3]
+//                                     if( curr && curr.shape == "aER"){
+//                                         i.comesAfter = null
+//                                     }
+//                                     for (let k = nodes.length - 1; k >= 0; k--){
+//                                         let curr = nodes[k];
+//                                         if(curr.shape == "iER"){
+//                                             console.log(curr.id);
+//                                             i.comesAfter = curr.id;
+//                                             break;
+//                                         }
+//                                     }
+                                  
+//                                 }
+//                             }
+//                         }
+//                         hidden = node.shape == 'Atomic ER';
+//                         break;
+//                     case "3":
+//                          //clear any modifications made to the dataset from View 1
+
+//                          for(const i of nodes){
+//                             if(i.shape == "aER" || i.id == 54321){
+//                                 if(i.id != 54321){
+//                                 i.comesAfter = null
+//                                 }
+//                                 else{
+//                                     var node_id = i.comesAfter
+//                                     var curr = nodes[node_id-3]
+//                                     if( curr && curr.shape == "aER"){
+//                                         i.comesAfter = null
+//                                     }
+//                                     for (let k = nodes.length - 1; k >= 0; k--){
+//                                         let curr = nodes[k];
+//                                         if(curr.shape == "iER"){
+//                                             console.log(curr.id);
+//                                             i.comesAfter = curr.id;
+//                                             break;
+//                                         }
+//                                     }
+                                  
+//                                 }
+//                             }
+//                         }
+
+//                         hidden = false; // Show all nodes
+//                         break;
+//                     case "4":
+
+//                      //clear any modifications made to the dataset from View 1
+
+//                      for(const i of nodes){
+//                         if(i.shape == "aER" || i.id == 54321){
+//                             if(i.id != 54321){
+//                             i.comesAfter = null
+//                             }
+//                             else{
+//                                 var node_id = i.comesAfter
+//                                 var curr = nodes[node_id-3]
+//                                 if( curr && curr.shape == "aER"){
+//                                     i.comesAfter = null
+//                                 }
+//                                 for (let k = nodes.length - 1; k >= 0; k--){
+//                                     let curr = nodes[k];
+//                                     if(curr.shape == "iER"){
+//                                         console.log(curr.id);
+//                                         i.comesAfter = curr.id;
+//                                         break;
+//                                     }
+//                                 }
+                              
+//                             }
+//                         }
+//                     }
+
+
+//                         break;
+//                     default:
+//                         hidden = false;
+//                 }
+//             }
+
+//             return {
+//                 ...node,
+//                 hidden
+//             };
+//         });
+//         setNodes([...updatedNodes]);
+
+//     };
 
 
     const handleNodeHover = (event, d) => {

--- a/src/NetworkGraph.js
+++ b/src/NetworkGraph.js
@@ -914,249 +914,90 @@ const loadNodesFromLocalStorage = () => {
     return null; // Return null if no nodes are saved
 };
 
-
 const handleFilterNodes = (filterType) => {
     // Save the updated nodes to Local Storage
-    var saved = loadNodesFromLocalStorage
+    var saved = loadNodesFromLocalStorage()
     if( saved == null){
-    saveNodesToLocalStorage(updatedNodes);
+    saveNodesToLocalStorage(nodes);
     }
 
-    let updatedNodes;
+    let updatedNodes = nodes
+
 
     switch (filterType) {
         case "1":
-    updatedNodes = nodes.map(node => {
-            let hidden = false;
-            if (node.id === 0 || node.id === 54321) {
-                hidden = false; // Always show nodes with id 1 and 2
-            } 
-            else {   
-                hidden = !(node.shape === 'aER' || node.shape === 'rER');
-            }
-                   
-
-    // Iterate backwards through the nodes array
-for (let i = nodes.length - 1; i >= 0; i--) {
-
-    const node = nodes[i];
-      // Find the previous aER node in the array
-      const prevAER = nodes.slice(0, i).reverse().find(n => n.shape === 'aER');
-
-
-    if(node.id == 54321){
-        if(prevAER ){
-        node.comesAfter = prevAER.id;
-        }
-    }
-
-    // Link all aER nodes together with a comesAfter relation
-    if (node.shape === 'aER') {
-        
-        // If there is a previous aER node, set the comesAfter property
-        if (prevAER) {
+            updatedNodes = nodes.map(node => {
+                let hidden = false;
+                if (node.id === 0 || node.id === 54321) {
+                    hidden = false; // Always show nodes with id 1 and 2
+                } 
+                else {   
+                    hidden = !(node.shape === 'aER' || node.shape === 'rER');
+                }
+                       
+    
+        // Iterate backwards through the nodes array
+    for (let i = nodes.length - 1; i >= 0; i--) {
+    
+        const node = nodes[i];
+          // Find the previous aER node in the array
+          const prevAER = nodes.slice(0, i).reverse().find(n => n.shape === 'aER');
+    
+    
+        if(node.id == 54321){
+            if(prevAER ){
             node.comesAfter = prevAER.id;
-        } 
-        else {
-            node.comesAfter = 0; // No previous aER, set to a default value
+            }
+        }
+    
+        // Link all aER nodes together with a comesAfter relation
+        if (node.shape === 'aER') {
+            
+            // If there is a previous aER node, set the comesAfter property
+            if (prevAER) {
+                node.comesAfter = prevAER.id;
+            } 
+            else {
+                node.comesAfter = 0; // No previous aER, set to a default value
+            }
         }
     }
-}
+    
+    return { ...node, hidden };
+    });
+    
 
-        return { ...node, hidden };
-        });
+            break;
+        case "2":
 
-        break;
+            updatedNodes = saved.map(node => {
+                let hidden = node.shape === 'Atomic ER';
 
+                return { ...node, hidden };
+            });
+            break;
+        case "3":
+            updatedNodes = saved.map(node => {
+              
 
+                return { ...node, hidden: false };
+            });
+            break;
+        case "4":
+            updatedNodes = saved.map(node => {
+                // ( custom logic to update nodes in case "4")
+
+                return { ...node, hidden: false };
+            });
+            break;
         default:
-            // For all other cases, load the nodes from Local Storage
-            const savedNodes = loadNodesFromLocalStorage();
-            if (savedNodes) {
-                updatedNodes = savedNodes.map(node => {
-                    let hidden;
-
-                    switch (filterType) {
-                        case "2":
-                            hidden = node.shape === 'Atomic ER';
-
-                            // (Your custom logic to update nodes in case "2")
-
-                            break;
-                        case "3":
-                            // (Your custom logic to update nodes in case "3")
-                            hidden = false;
-                            break;
-                        case "4":
-                            // (Your custom logic to update nodes in case "4")
-                            hidden = false;
-                            break;
-                        default:
-                            hidden = false;
-                            break;
-                    }
-
-                    return { ...node, hidden };
-                });
-            } else {
-                // Fallback if no saved nodes are found
-                console.error("No saved nodes found in Local Storage.");
-                return;
-            }
+            updatedNodes = saved.map(node => ({ ...node, hidden: false }));
             break;
     }
 
     // Update the nodes state with the modified nodes
     setNodes(updatedNodes);
 };
-
-
-//     const handleFilterNodes = (filterType) => {
-//   // Save the current nodes to Local Storage before making changes
-//   saveNodesToLocalStorage(nodes);
-
-//   let updatedNodes;
-
-//     updatedNodes = nodes.map(node => {
-//             let hidden = false;
-//             if (node.id === 0 || node.id === 54321) {
-//                 hidden = false; // Always show nodes with id 1 and 2
-//             } 
-//             else {
-//                 switch (filterType) {
-//                     case "1":
-//                         hidden = !(node.shape === 'aER' || node.shape === 'rER');
-//                         // Find last node(connected to end) to use later
-
-//     // Iterate backwards through the nodes array
-// for (let i = nodes.length - 1; i >= 0; i--) {
-
-//     const node = nodes[i];
-//       // Find the previous aER node in the array
-//       const prevAER = nodes.slice(0, i).reverse().find(n => n.shape === 'aER');
-
-
-//     if(node.id == 54321){
-//         if(prevAER ){
-//         node.comesAfter = prevAER.id;
-//         }
-//     }
-
-//     // Link all aER nodes together with a comesAfter relation
-//     if (node.shape === 'aER') {
-        
-//         // If there is a previous aER node, set the comesAfter property
-//         if (prevAER) {
-//             node.comesAfter = prevAER.id;
-//         } 
-//         else {
-//             node.comesAfter = 0; // No previous aER, set to a default value
-//         }
-//     }
-// }
-
-                
-//                         break;
-//                     case "2":
-//                         //clear any modifications made to the dataset from View 1
-
-//                         for(const i of nodes){
-//                             if(i.shape == "aER" || i.id == 54321){
-//                                 if(i.id != 54321){
-//                                 i.comesAfter = null
-//                                 }
-//                                 else{
-//                                     var node_id = i.comesAfter
-//                                     var curr = nodes[node_id-3]
-//                                     if( curr && curr.shape == "aER"){
-//                                         i.comesAfter = null
-//                                     }
-//                                     for (let k = nodes.length - 1; k >= 0; k--){
-//                                         let curr = nodes[k];
-//                                         if(curr.shape == "iER"){
-//                                             console.log(curr.id);
-//                                             i.comesAfter = curr.id;
-//                                             break;
-//                                         }
-//                                     }
-                                  
-//                                 }
-//                             }
-//                         }
-//                         hidden = node.shape == 'Atomic ER';
-//                         break;
-//                     case "3":
-//                          //clear any modifications made to the dataset from View 1
-
-//                          for(const i of nodes){
-//                             if(i.shape == "aER" || i.id == 54321){
-//                                 if(i.id != 54321){
-//                                 i.comesAfter = null
-//                                 }
-//                                 else{
-//                                     var node_id = i.comesAfter
-//                                     var curr = nodes[node_id-3]
-//                                     if( curr && curr.shape == "aER"){
-//                                         i.comesAfter = null
-//                                     }
-//                                     for (let k = nodes.length - 1; k >= 0; k--){
-//                                         let curr = nodes[k];
-//                                         if(curr.shape == "iER"){
-//                                             console.log(curr.id);
-//                                             i.comesAfter = curr.id;
-//                                             break;
-//                                         }
-//                                     }
-                                  
-//                                 }
-//                             }
-//                         }
-
-//                         hidden = false; // Show all nodes
-//                         break;
-//                     case "4":
-
-//                      //clear any modifications made to the dataset from View 1
-
-//                      for(const i of nodes){
-//                         if(i.shape == "aER" || i.id == 54321){
-//                             if(i.id != 54321){
-//                             i.comesAfter = null
-//                             }
-//                             else{
-//                                 var node_id = i.comesAfter
-//                                 var curr = nodes[node_id-3]
-//                                 if( curr && curr.shape == "aER"){
-//                                     i.comesAfter = null
-//                                 }
-//                                 for (let k = nodes.length - 1; k >= 0; k--){
-//                                     let curr = nodes[k];
-//                                     if(curr.shape == "iER"){
-//                                         console.log(curr.id);
-//                                         i.comesAfter = curr.id;
-//                                         break;
-//                                     }
-//                                 }
-                              
-//                             }
-//                         }
-//                     }
-
-
-//                         break;
-//                     default:
-//                         hidden = false;
-//                 }
-//             }
-
-//             return {
-//                 ...node,
-//                 hidden
-//             };
-//         });
-//         setNodes([...updatedNodes]);
-
-//     };
 
 
     const handleNodeHover = (event, d) => {

--- a/src/NetworkGraph.js
+++ b/src/NetworkGraph.js
@@ -748,12 +748,12 @@ const NetworkGraph = () => {
             setSelectedNodes(prevNodes => {
                 const newNodes = [...prevNodes, d];
 
-//  Show popover if more than one node is selected
- if (newNodes.length > 1 && shiftRef.current == false) {
-    setAnchorElMultiNode(event.currentTarget); // Set the popover anchor to the event target
-} else {
-    setAnchorElMultiNode(null); // Hide popover if only one node is selected
-}
+                //  Show popover if more than one node is selected
+                if (newNodes.length > 1 && shiftRef.current == false) {
+                    setAnchorElMultiNode(event.currentTarget); // Set the popover anchor to the event target
+                } else {
+                    setAnchorElMultiNode(null); // Hide popover if only one node is selected
+                }
 
                 updateNodeBorders(newNodes);
                 return newNodes;
@@ -936,104 +936,104 @@ const NetworkGraph = () => {
         }
     };
 
-// Function to save nodes to Local Storage
-const saveNodesToLocalStorage = (nodes) => {
-    localStorage.setItem('nodes', JSON.stringify(nodes));
-};
+    // Function to save nodes to Local Storage
+    const saveNodesToLocalStorage = (nodes) => {
+        localStorage.setItem('nodes', JSON.stringify(nodes));
+    };
 
-// Function to load nodes from Local Storage
-const loadNodesFromLocalStorage = () => {
-    const savedNodes = localStorage.getItem('nodes');
-    if (savedNodes) {
-        return JSON.parse(savedNodes);
-    }
-    return null; // Return null if no nodes are saved
-};
-
-const handleFilterNodes = (filterType) => {
-    // Save the updated nodes to Local Storage
-    var saved = loadNodesFromLocalStorage()
-    if( saved == null){
-    saveNodesToLocalStorage(nodes);
-    }
-
-    let updatedNodes = nodes
-
-
-    switch (filterType) {
-        case "1":
-            updatedNodes = nodes.map(node => {
-                let hidden = false;
-                if (node.id === 0 || node.id === 54321) {
-                    hidden = false; // Always show nodes with id 1 and 2
-                } 
-                else {   
-                    hidden = !(node.shape === 'aER' || node.shape === 'rER');
-                }
-                       
-    
-        // Iterate backwards through the nodes array
-    for (let i = nodes.length - 1; i >= 0; i--) {
-    
-        const node = nodes[i];
-          // Find the previous aER node in the array
-          const prevAER = nodes.slice(0, i).reverse().find(n => n.shape === 'aER');
-    
-    
-        if(node.id == 54321){
-            if(prevAER ){
-            node.comesAfter = prevAER.id;
-            }
+    // Function to load nodes from Local Storage
+    const loadNodesFromLocalStorage = () => {
+        const savedNodes = localStorage.getItem('nodes');
+        if (savedNodes) {
+            return JSON.parse(savedNodes);
         }
-    
-        // Link all aER nodes together with a comesAfter relation
-        if (node.shape === 'aER') {
-            
-            // If there is a previous aER node, set the comesAfter property
-            if (prevAER) {
-                node.comesAfter = prevAER.id;
-            } 
-            else {
-                node.comesAfter = 0; // No previous aER, set to a default value
-            }
+        return null; // Return null if no nodes are saved
+    };
+
+    const handleFilterNodes = (filterType) => {
+        // Save the updated nodes to Local Storage
+        var saved = loadNodesFromLocalStorage()
+        if (saved == null) {
+            saveNodesToLocalStorage(nodes);
         }
-    }
-    
-    return { ...node, hidden };
-    });
-    
 
-            break;
-        case "2":
+        let updatedNodes = nodes
 
-            updatedNodes = saved.map(node => {
-                let hidden = node.shape === 'Atomic ER';
 
-                return { ...node, hidden };
-            });
-            break;
-        case "3":
-            updatedNodes = saved.map(node => {
-              
+        switch (filterType) {
+            case "1":
+                updatedNodes = nodes.map(node => {
+                    let hidden = false;
+                    if (node.id === 0 || node.id === 54321) {
+                        hidden = false; // Always show nodes with id 1 and 2
+                    }
+                    else {
+                        hidden = !(node.shape === 'aER' || node.shape === 'rER');
+                    }
 
-                return { ...node, hidden: false };
-            });
-            break;
-        case "4":
-            updatedNodes = saved.map(node => {
-                // ( custom logic to update nodes in case "4")
 
-                return { ...node, hidden: false };
-            });
-            break;
-        default:
-            updatedNodes = saved.map(node => ({ ...node, hidden: false }));
-            break;
-    }
+                    // Iterate backwards through the nodes array
+                    for (let i = nodes.length - 1; i >= 0; i--) {
 
-    // Update the nodes state with the modified nodes
-    setNodes(updatedNodes);
-};
+                        const node = nodes[i];
+                        // Find the previous aER node in the array
+                        const prevAER = nodes.slice(0, i).reverse().find(n => n.shape === 'aER');
+
+
+                        if (node.id == 54321) {
+                            if (prevAER) {
+                                node.comesAfter = prevAER.id;
+                            }
+                        }
+
+                        // Link all aER nodes together with a comesAfter relation
+                        if (node.shape === 'aER') {
+
+                            // If there is a previous aER node, set the comesAfter property
+                            if (prevAER) {
+                                node.comesAfter = prevAER.id;
+                            }
+                            else {
+                                node.comesAfter = 0; // No previous aER, set to a default value
+                            }
+                        }
+                    }
+
+                    return { ...node, hidden };
+                });
+
+
+                break;
+            case "2":
+
+                updatedNodes = saved.map(node => {
+                    let hidden = node.shape === 'Atomic ER';
+
+                    return { ...node, hidden };
+                });
+                break;
+            case "3":
+                updatedNodes = saved.map(node => {
+
+
+                    return { ...node, hidden: false };
+                });
+                break;
+            case "4":
+                updatedNodes = saved.map(node => {
+                    // ( custom logic to update nodes in case "4")
+
+                    return { ...node, hidden: false };
+                });
+                break;
+            default:
+                updatedNodes = saved.map(node => ({ ...node, hidden: false }));
+                break;
+        }
+
+        // Update the nodes state with the modified nodes
+        setNodes(updatedNodes);
+    };
 
 
     const updateNodeBorders = (selected) => {


### PR DESCRIPTION
- Made node manipulation static after physx ticks end
- Coordinates can now be saved and reloaded via CSV
- Added popup alert notifying users of loss of changes before reloading
- Select all nodes with Shift+A
- Minor UI changes and bug fixes