### PR TITLE
Coord saving jitteriness

### DIFF
--- a/src/NetworkGraph.js
+++ b/src/NetworkGraph.js
@@ -838,6 +838,7 @@ const NetworkGraph = () => {
             };
             reader.readAsText(file);
         }
+        event.target.value = ''; // Clear the file input after processing
     };
 
     const parseCSV = (data) => {


### PR DESCRIPTION
- Removed warning for refresh
- Allow session data to persist after refreshing, or closing & reopening tab
- Added a 'clear' button to remove all nodes (except for start & end) with a popup warning to confirm
- Some minor bug fixes
Resolves #22